### PR TITLE
Fix rms-set-scales function to make it work with sass 3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'sass', '~> 3.2.14'
-gem 'compass', '~> 0.12'
+gem 'sass', '~> 3.4'
+gem 'compass', '~> 1.0'
 gem 'modular-scale', '~> 2.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  compass (~> 0.12)
+  compass (~> 1.0)
   modular-scale (~> 2.0.4)
-  sass (~> 3.2.14)
+  sass (~> 3.4)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.2 (October 23, 2015)
+
+- Changed Gemfile to require Sass 3.4.x and Compass 1.0.x
+
 ## 0.2.1 (April 8, 2014)
 
 - Changed Gemfile to require Sass 3.2.x

--- a/lib/responsive-modular-scale.rb
+++ b/lib/responsive-modular-scale.rb
@@ -5,6 +5,6 @@ extension_path = File.expand_path(File.join(File.dirname(__FILE__), ".."))
 Compass::Frameworks.register('responsive-modular-scale', :path => extension_path)
 
 module ResponsiveModularScale
-  VERSION = "0.2.1"
-  DATE = "2014-04-08"
+  VERSION = "0.2.2"
+  DATE = "2015-10-23"
 end

--- a/stylesheets/responsive-modular-scale/_functions.scss
+++ b/stylesheets/responsive-modular-scale/_functions.scss
@@ -23,16 +23,16 @@ $rms-usepixels: false;
     // If more than one argument was given
     @if length($args) > 1 {
       // Remove the default breakpoints and intervals
-      $rms-intervals: ();
+      $rms-intervals: () !global;
 
       @for $i from 2 through length($args) {
         // If a list item only has one value, assume it's an interval and set the breakpoint to 0px
         @if length(nth($args, $i)) == 1 {
-          $rms-intervals: append($rms-intervals, 0px nth($args, $i));
+          $rms-intervals: append($rms-intervals, 0px nth($args, $i)) !global;
         }
         // Otherwise copy the list as-is
         @else {
-          $rms-intervals: append($rms-intervals, nth($args, $i));
+          $rms-intervals: append($rms-intervals, nth($args, $i)) !global;
         }
       }
     }


### PR DESCRIPTION
Quoting sass backwards incompatibilty change in 3.4.0:
"All variable assignments not at the top level of the document are now local by default.
If there’s a global variable with the same name, it won’t be overwritten unless the
!global flag is used. For example, $var: value !global will assign to $var globally.
This behavior can be detected using feature-exists(global-variable-shadowing)."

@see http://sass-lang.com/documentation/file.SASS_CHANGELOG.html
@see http://stackoverflow.com/q/27706643/1026660
